### PR TITLE
FTL_READ() and FTL_write() have variable type problem.

### DIFF
--- a/hw/block/femu/ssd/ftl.c
+++ b/hw/block/femu/ssd/ftl.c
@@ -154,7 +154,7 @@ void FTL_TERM(struct ssdstate *ssd)
 
 int64_t FTL_READ(struct ssdstate *ssd, int64_t sector_nb, unsigned int length)
 {
-	int ret;
+	int64_t ret;
 
 #ifdef GET_FTL_WORKLOAD
 	FILE* fp_workload = fopen("./data/workload_ftl.txt","a");
@@ -182,7 +182,7 @@ int64_t FTL_READ(struct ssdstate *ssd, int64_t sector_nb, unsigned int length)
 
 int64_t FTL_WRITE(struct ssdstate *ssd, int64_t sector_nb, unsigned int length)
 {
-	int ret;
+	int64_t ret;
 
 #ifdef GET_FTL_WORKLOAD
 	FILE* fp_workload = fopen("./data/workload_ftl.txt","a");


### PR DESCRIPTION
In `FTL_WRITE()`, it calls `_FTL_WRITE()` that returns `int64_t` variable.
However, `FTL_WRITE()` saves the returned value in `int` variable (i.e. `int ret`) instead of variable with `int64_t` type.
As a result, the latency is not normally delivered to `SSD_WRITE()`.

And, in `FTL_READ()`, `int ret` is declared, but it is not used. So, it has no problem.
