### PR TITLE
Backport QEMU v4.0.0 #e014dbe

### DIFF
--- a/block/gluster.c
+++ b/block/gluster.c
@@ -17,6 +17,10 @@
 #include "qemu/error-report.h"
 #include "qemu/cutils.h"
 
+#ifdef CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT
+# define glfs_ftruncate(fd, offset) glfs_ftruncate(fd, offset, NULL, NULL)
+#endif
+
 #define GLUSTER_OPT_FILENAME        "filename"
 #define GLUSTER_OPT_VOLUME          "volume"
 #define GLUSTER_OPT_PATH            "path"

--- a/configure
+++ b/configure
@@ -301,6 +301,7 @@ glusterfs=""
 glusterfs_xlator_opt="no"
 glusterfs_discard="no"
 glusterfs_zerofill="no"
+glusterfs_ftruncate_has_stat="no"
 gtk=""
 gtkabi=""
 gtk_gl="no"
@@ -3533,6 +3534,18 @@ if test "$glusterfs" != "no" ; then
     if $pkg_config --atleast-version=6 glusterfs-api; then
       glusterfs_zerofill="yes"
     fi
+    cat > $TMPC << EOF
+#include <glusterfs/api/glfs.h>
+int
+main(void)
+{
+        /* new glfs_ftruncate() passes two additional args */
+            return glfs_ftruncate(NULL, 0, NULL, NULL);
+        }
+EOF
+    if compile_prog "$glusterfs_cflags" "$glusterfs_libs" ; then
+        glusterfs_ftruncate_has_stat="yes"
+    fi
   else
     if test "$glusterfs" = "yes" ; then
       feature_not_found "GlusterFS backend support" \
@@ -5695,6 +5708,10 @@ fi
 
 if test "$glusterfs_zerofill" = "yes" ; then
   echo "CONFIG_GLUSTERFS_ZEROFILL=y" >> $config_host_mak
+fi
+
+if test "$glusterfs_ftruncate_has_stat" = "yes" ; then
+  echo "CONFIG_GLUSTERFS_FTRUNCATE_HAS_STAT=y" >> $config_host_mak
 fi
 
 if test "$libssh2" = "yes" ; then


### PR DESCRIPTION
[see here](https://github.com/qemu/qemu/commit/e014dbe74e0484188164c61ff6843f8a04a8cb9d)
"gluster: Handle changed glfs_ftruncate signature"

This is so that femu compiles on platform with newer Glusterfs library.