### PR TITLE
Multithreaded Poller and Optimized IO path

### DIFF
--- a/hw/block/femu/femu.c
+++ b/hw/block/femu/femu.c
@@ -1068,6 +1068,7 @@ static Property femu_props[] = {
     DEFINE_PROP_UINT32("namespaces", FemuCtrl, num_namespaces, 1),
     DEFINE_PROP_UINT32("queues", FemuCtrl, num_io_queues, 1),
     DEFINE_PROP_UINT32("entries", FemuCtrl, max_q_ents, 0x7ff),
+    DEFINE_PROP_UINT8("multipoller_enabled", FemuCtrl, multipoller_enabled, 0),
     DEFINE_PROP_UINT8("max_cqes", FemuCtrl, max_cqes, 0x4),
     DEFINE_PROP_UINT8("max_sqes", FemuCtrl, max_sqes, 0x6),
     DEFINE_PROP_UINT8("stride", FemuCtrl, db_stride, 0),

--- a/hw/block/femu/ftl/ftl.h
+++ b/hw/block/femu/ftl/ftl.h
@@ -192,8 +192,8 @@ struct ssd {
     struct line_mgmt lm;
 
     /* lockless ring for communication with NVMe IO thread */
-    struct rte_ring *to_ftl;
-    struct rte_ring *to_poller;
+    struct rte_ring **to_ftl;
+    struct rte_ring **to_poller;
     bool *dataplane_started_ptr;
     QemuThread ftl_thread;
 };


### PR DESCRIPTION
Changes in this PR are:

1. Multithreaded Pollers
Multithreaded pollers can be enabled by providing command line parameter when starting FEMU (```multipoller_enabled=1```). If parameter is not specified, FEMU will start with single-threaded poller.

2. Optimized IO Path for NoSSD
The function to perform read and write in NoSSD mode is now separated from Blackbox mode.