### PR TITLE
Check all PPAs for OC requests to prevent from potential segmentation…

### DIFF
--- a/hw/block/femu/femu.c
+++ b/hw/block/femu/femu.c
@@ -380,6 +380,8 @@ static uint16_t nvme_io_cmd(FemuCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
     uint32_t nsid = le32_to_cpu(cmd->nsid);
 
     if (nsid == 0 || nsid > n->num_namespaces) {
+		femu_err("%s, NVME_INVALID_NSID %lu\n",
+									__func__, nsid);
         return NVME_INVALID_NSID | NVME_DNR;
     }
 
@@ -431,6 +433,8 @@ static uint16_t nvme_io_cmd(FemuCtrl *n, NvmeCmd *cmd, NvmeRequest *req)
         return femu_oc12_erase_async(n, ns, cmd, req);
 
     default:
+		femu_err("%s, NVME_INVALID_OPCODE\n",
+									__func__);
         return NVME_INVALID_OPCODE | NVME_DNR;
     }
 }

--- a/hw/block/femu/nvme.h
+++ b/hw/block/femu/nvme.h
@@ -1287,6 +1287,9 @@ void nvme_set_error_page(FemuCtrl *n, uint16_t sqid, uint16_t cid,
 uint16_t femu_nvme_rw_check_req(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
         NvmeRequest *req, uint64_t slba, uint64_t elba, uint32_t nlb,
         uint16_t ctrl, uint64_t data_size, uint64_t meta_size);
+uint16_t femu_oc_rw_check_req(FemuCtrl *n, NvmeNamespace *ns, NvmeCmd *cmd,
+        NvmeRequest *req, uint64_t *psl, uint32_t nr_pages, uint32_t nlb,
+        uint16_t ctrl, uint64_t data_size, uint64_t meta_size);
 int nvme_add_kvm_msi_virq(FemuCtrl *n, NvmeCQueue *cq);
 void nvme_remove_kvm_msi_virq(NvmeCQueue *cq);
 int nvme_set_guest_notifier(FemuCtrl *n, EventNotifier *notifier, uint32_t qid);


### PR DESCRIPTION
This patch checks all PPAs of an OCSSD request.
This prevents FEMU from segmentation fault caused by wrong PPA from guest VM.