### PR TITLE
Add TLC-NAND and QLC-NAND Support to FEMU

### DIFF
--- a/femu-scripts/run-whitebox.sh
+++ b/femu-scripts/run-whitebox.sh
@@ -71,6 +71,7 @@ FEMU_OPTIONS=${FEMU_OPTIONS}",lsec_size=${hw_sector_size}"
 FEMU_OPTIONS=${FEMU_OPTIONS}",lsecs_per_pg=${num_sectors_per_page}"
 FEMU_OPTIONS=${FEMU_OPTIONS}",lpgs_per_blk=${num_pages_per_block}"
 FEMU_OPTIONS=${FEMU_OPTIONS}",femu_mode=0"
+#FEMU_OPTIONS=${FEMU_OPTIONS}",cell_type=3" # 3 for TLC, 4 for QLC, 2 (default) for MLC
 
 #echo ${FEMU_OPTIONS}
 

--- a/hw/block/femu/backend/dram.h
+++ b/hw/block/femu/backend/dram.h
@@ -3,11 +3,14 @@
 
 #include <stdint.h>
 
+typedef uint8_t celltype;
+
 /* DRAM backend SSD address space */
 typedef struct SsdDramBackend {
     void    *logical_space;
     int64_t size; /* in bytes */
     int     femu_mode;
+    celltype cell_type;
 } SsdDramBackend;
 
 int init_dram_backend(SsdDramBackend **mbe, int64_t nbytes);

--- a/hw/block/femu/femu.c
+++ b/hw/block/femu/femu.c
@@ -541,6 +541,7 @@ static void femu_realize(PCIDevice *pci_dev, Error **errp)
 
     init_dram_backend(&n->mbe, bs_size);
     n->mbe->femu_mode = n->femu_mode;
+    n->mbe->cell_type = n->cell_type;
 
     n->completed = 0;
     n->start_time = time(NULL);
@@ -649,6 +650,7 @@ static Property femu_props[] = {
     DEFINE_PROP_UINT16("vid", FemuCtrl, vid, 0x1d1d),
     DEFINE_PROP_UINT16("did", FemuCtrl, did, 0x1f1f),
     DEFINE_PROP_UINT8("femu_mode", FemuCtrl, femu_mode, FEMU_NOSSD_MODE),
+    DEFINE_PROP_UINT8("cell_type", FemuCtrl, cell_type, MLC_CELL),
     DEFINE_PROP_UINT8("lver", FemuCtrl, lver, 0x2),
     DEFINE_PROP_UINT16("lsec_size", FemuCtrl, oc_params.sec_size, 4096),
     DEFINE_PROP_UINT8("lsecs_per_pg", FemuCtrl, oc_params.secs_per_pg, 4),

--- a/hw/block/femu/nvme.h
+++ b/hw/block/femu/nvme.h
@@ -820,6 +820,12 @@ typedef struct DMAOff {
     dma_addr_t len;
 } DMAOff;
 
+enum celltype {
+    MLC_CELL = 2,
+    TLC_CELL = 3,
+    QLC_CELL = 4,
+};
+
 typedef struct NvmeSQueue {
     struct FemuCtrl *ctrl;
     uint8_t     phys_contig;
@@ -1078,9 +1084,15 @@ typedef struct FemuCtrl {
     pthread_spinlock_t chnl_locks[FEMU_MAX_NUM_CHNLS];
 
     /* Latency numbers for whitebox-mode only */
-    int64_t upg_rd_lat_ns; /* upper page in MLC */
-    int64_t lpg_rd_lat_ns; /* lower page in MLC */
+    int64_t upg_rd_lat_ns; /* upper page in MLC/TLC/QLC */
+    int64_t cpg_rd_lat_ns; /* center page in TLC */
+    int64_t cupg_rd_lat_ns; /* center-upper page in QLC */
+    int64_t clpg_rd_lat_ns; /* center-lower page in QLC */
+    int64_t lpg_rd_lat_ns; /* lower page in MLC/TLC/QLC */
     int64_t upg_wr_lat_ns;
+    int64_t cpg_wr_lat_ns;
+    int64_t cupg_wr_lat_ns;
+    int64_t clpg_wr_lat_ns;
     int64_t lpg_wr_lat_ns;
     int64_t blk_er_lat_ns;
     int64_t chnl_pg_xfer_lat_ns;
@@ -1102,6 +1114,7 @@ typedef struct FemuCtrl {
 
     uint8_t         multipoller_enabled;
     uint32_t        num_poller;
+    celltype        cell_type;
 } FemuCtrl;
 
 typedef struct NvmePollerThreadArgument {

--- a/hw/block/femu/ocssd/nand.c
+++ b/hw/block/femu/ocssd/nand.c
@@ -9,7 +9,7 @@
 
 /*
  * Lower/Upper page pairing in one block
- * It is what it is.
+ * Shadow page programming sequence to reduce cell-to-cell interference
  */
 void init_nand_page_pairing(FemuCtrl *n)
 {
@@ -30,3 +30,62 @@ void init_nand_page_pairing(FemuCtrl *n)
     }
 }
 
+// TLC Layout as described in the paper
+// Characterization and Error-Correcting Codes for TLC Flash Memories ICNC'2012
+// by Yaakobi et. al.
+
+void init_tlc_page_pairing(FemuCtrl *n)
+{
+    int i, j;
+    int rows = (MAX_SUPPORTED_PAGES_PER_BLOCK + 5) / 6;
+    int lpflag = TLC_LOWER_PAGE;
+    int page_per_row=6;
+
+    int lowp[] = {0, 1, 2, 3, 4, 5};
+    int centerp[] = {6, 7};
+
+    for (i = 0; i < sizeof(lowp)/sizeof(lowp[0]); i++)
+        tlc_tbl[lowp[i]] = TLC_LOWER_PAGE;
+
+    for (i = 0; i < sizeof(centerp)/sizeof(centerp[0]); i++)
+        tlc_tbl[centerp[i]] = TLC_CENTER_PAGE;
+
+    for (i = 0; i < rows -2; i++) {
+        for(j = 0; j < page_per_row; j+=2) {
+            int idx = 8 + (i*page_per_row) + j;
+            tlc_tbl[idx] = tlc_tbl[idx+1] = lpflag;
+            lpflag = (lpflag == TLC_UPPER_PAGE) ? TLC_LOWER_PAGE : lpflag + 1;
+        }
+    }
+}
+
+// QLC-NAND Flash Mapping with Shadow-Page programming Sequence
+
+void init_qlc_page_pairing(FemuCtrl *n)
+{
+	int i, j;
+    int rows = (MAX_SUPPORTED_PAGES_PER_BLOCK + 7) / 8;
+    int lpflag = QLC_LOWER_PAGE;
+	int page_per_row=8;
+
+    int lowp[] = {0, 1, 2, 3, 4, 5, 8, 9};
+    int centerlp[] = {6, 7, 10, 11};
+    int centerup[] = {12, 13};
+
+    for (i = 0; i < sizeof(lowp)/sizeof(lowp[0]); i++)
+        qlc_tbl[lowp[i]] = QLC_LOWER_PAGE;
+
+    for (i = 0; i < sizeof(centerlp)/sizeof(centerlp[0]); i++)
+        qlc_tbl[centerlp[i]] = QLC_LOWER_CENTER_PAGE;
+
+    for (i = 0; i < sizeof(centerup)/sizeof(centerup[0]); i++)
+        qlc_tbl[centerup[i]] = QLC_UPPER_CENTER_PAGE;
+
+    for (i = 0; i < rows -3; i++) {
+        for (j = 0; j < page_per_row; j+=2) {
+            int idx = 8 + (i*page_per_row) + j;
+            tlc_tbl[idx] = tlc_tbl[idx+1] = lpflag;
+            lpflag = (lpflag == QLC_UPPER_PAGE) ? QLC_LOWER_PAGE : lpflag + 1;
+        }
+    }
+}

--- a/hw/block/femu/ocssd/nand.h
+++ b/hw/block/femu/ocssd/nand.h
@@ -9,8 +9,52 @@
 #define CHNL_PAGE_TRANSFER_LATENCY_NS     (52433)
 #define NAND_BLOCK_ERASE_LATENCY_NS       (3000000)
 
+/* TLC NAND latency numbers in nanoseconds
+   Based on the paper:
+   SimpleSSD: Modeling Solid State Drives for Holistic System Simulation
+*/
+
+#define TLC_LOWER_PAGE_READ_LATENCY_NS   (56500)
+#define TLC_CENTER_PAGE_READ_LATENCY_NS   (77500)
+#define TLC_UPPER_PAGE_READ_LATENCY_NS   (106000)
+
+#define TLC_LOWER_PAGE_WRITE_LATENCY_NS  (820500)
+#define TLC_CENTER_PAGE_WRITE_LATENCY_NS  (2225000)
+#define TLC_UPPER_PAGE_WRITE_LATENCY_NS  (5734000)
+
+#define TLC_CHNL_PAGE_TRANSFER_LATENCY_NS     (52433)
+#define TLC_BLOCK_ERASE_LATENCY_NS       (3000000)
+
+/* QLC NAND latency numbers in nanoseconds
+   Read Latency is extrapolated from TLC drives based on Micron FMS'19 Presentation:
+   Component-Level Characterization of 3D TLC, QLC, and Low-Latency NAND
+   Write Latency is increased similar to read latencies, but may be higher in practice.
+*/
+
+#define QLC_LOWER_PAGE_READ_LATENCY_NS   (TLC_LOWER_PAGE_READ_LATENCY_NS * 1.05)
+#define QLC_CENTER_LOWER_PAGE_READ_LATENCY_NS   (TLC_CENTER_PAGE_READ_LATENCY_NS * 1.1)
+#define QLC_CENTER_UPPER_PAGE_READ_LATENCY_NS   (TLC_UPPER_PAGE_READ_LATENCY_NS * 1.2)
+#define QLC_UPPER_PAGE_READ_LATENCY_NS   (TLC_UPPER_PAGE_READ_LATENCY_NS * 1.6)
+
+#define QLC_LOWER_PAGE_WRITE_LATENCY_NS  (TLC_LOWER_PAGE_WRITE_LATENCY_NS * 1.05)
+#define QLC_CENTER_LOWER_PAGE_WRITE_LATENCY_NS  (TLC_CENTER_PAGE_WRITE_LATENCY_NS * 1.1)
+#define QLC_CENTER_UPPER_PAGE_WRITE_LATENCY_NS  (TLC_UPPER_PAGE_WRITE_LATENCY_NS * 1.2)
+#define QLC_UPPER_PAGE_WRITE_LATENCY_NS  (TLC_UPPER_PAGE_WRITE_LATENCY_NS * 1.6)
+
+#define QLC_CHNL_PAGE_TRANSFER_LATENCY_NS	(52433)
+#define QLC_BLOCK_ERASE_LATENCY_NS       (3000000)
+
 #define MLC_LOWER_PAGE  (0)
 #define MLC_UPPER_PAGE  (1)
+
+#define TLC_LOWER_PAGE (0)
+#define TLC_CENTER_PAGE (1)
+#define TLC_UPPER_PAGE (2)
+
+#define QLC_LOWER_PAGE (0)
+#define QLC_LOWER_CENTER_PAGE (1)
+#define QLC_UPPER_CENTER_PAGE (2)
+#define QLC_UPPER_PAGE (3)
 
 #define PPA_CH(ln, ppa)  ((ppa & ln->ppaf.ch_mask) >> ln->ppaf.ch_offset)
 #define PPA_LUN(ln, ppa) ((ppa & ln->ppaf.lun_mask) >> ln->ppaf.lun_offset)
@@ -22,13 +66,24 @@
 #define MAX_SUPPORTED_PAGES_PER_BLOCK (512)
 /* Lower/Upper page format within one block */
 static int mlc_tbl[MAX_SUPPORTED_PAGES_PER_BLOCK];
+static int tlc_tbl[MAX_SUPPORTED_PAGES_PER_BLOCK];
+static int qlc_tbl[MAX_SUPPORTED_PAGES_PER_BLOCK];
 
-static inline bool is_upg(int pg)
+static inline uint8_t get_page_type(FemuCtrl *n, int pg)
 {
-    return mlc_tbl[pg];
+    switch (n->cell_type) {
+        case TLC_CELL:
+            return tlc_tbl[pg];
+        case QLC_CELL:
+            return qlc_tbl[pg];
+        default:
+            return mlc_tbl[pg];
+    }
 }
 
 void init_nand_page_pairing(FemuCtrl *n);
+void init_tlc_page_pairing(FemuCtrl *n);
+void init_qlc_page_pairing(FemuCtrl *n);
 
 #endif
 

--- a/hw/block/femu/ocssd/oc12.h
+++ b/hw/block/femu/ocssd/oc12.h
@@ -243,7 +243,7 @@ typedef struct AddrBucket {
     int  ch;
     int  lun;
     int  pg;
-    bool is_upg;
+    uint8_t  page_type;
     int  cnt;
 } AddrBucket;
 

--- a/hw/block/femu/ocssd/oc20.c
+++ b/hw/block/femu/ocssd/oc20.c
@@ -1344,12 +1344,7 @@ static int oc20_init_misc(FemuCtrl *n)
 {
     int ret;
 
-    n->upg_rd_lat_ns = NAND_UPPER_PAGE_READ_LATENCY_NS;
-    n->lpg_rd_lat_ns = NAND_LOWER_PAGE_READ_LATENCY_NS;
-    n->upg_wr_lat_ns = NAND_UPPER_PAGE_WRITE_LATENCY_NS;
-    n->lpg_wr_lat_ns = NAND_LOWER_PAGE_WRITE_LATENCY_NS;
-    n->blk_er_lat_ns = NAND_BLOCK_ERASE_LATENCY_NS;
-    n->chnl_pg_xfer_lat_ns = CHNL_PAGE_TRANSFER_LATENCY_NS;
+	set_latency(n);
 
     for (int i = 0; i < FEMU_MAX_NUM_CHNLS; i++) {
         n->chnl_next_avail_time[i] = 0;

--- a/hw/block/femu/ocssd/oc20.h
+++ b/hw/block/femu/ocssd/oc20.h
@@ -241,7 +241,7 @@ typedef struct Oc20AddrBucket {
     int  ch;
     int  lun;
     int  pg;
-    bool is_upg;
+    uint8_t page_type;
     int  cnt;
 } Oc20AddrBucket;
 

--- a/hw/block/femu/ocssd/timing.h
+++ b/hw/block/femu/ocssd/timing.h
@@ -3,6 +3,6 @@
 
 int64_t advance_channel_timestamp(FemuCtrl *n, int ch, uint64_t now, int opcode);
 int64_t advance_chip_timestamp(FemuCtrl *n, int lunid, uint64_t now, int opcode,
-                               bool is_upg);
-
+                               uint8_t page_type);
+void set_latency(FemuCtrl *n);
 #endif


### PR DESCRIPTION
Hi Huaicheng,

Thank you for open-sourcing FEMU and for actively maintaining the project.
I wanted to ask your views on extending FEMU to support TLC and QLC flash based research?
The following PR adds a parameter `cell_type` to determine the type of underlying NAND flash device.
Based on the device type, appropriate page latency is added to each page access.
The current TLC and QLC latency I have added are based on [1][2].
If you have other more accurate source for these latencies, kindly let me know.

If you think this work is useful, I will be happy to get more feedback from you and bring the code to a shape that can be merged to master.

Thank you,
Shehbaz

-----------------------------------------------------------------------------------------------------------
    This PR extends the default FEMU MLC-NAND Interface to emulate
    TLC and QLC Flash Drive.

    The latency values for each drive are derived from:

    1) SimpleSSD: Modeling Solid State Drives for Holistic System Simulation
    2) Component-Level Characterization of 3D TLC, QLC, and Low-Latency NAND (FMS'20)

    Each device contains the same number of pages per block, however the
    type of page changes based on the "cell_type" parameter specified while
    running FEMU.

    cell_type = MLC_CELL (2) has two types of pages - UP, LP
    This is the default device operation mode.
    cell_type = TLC_CELL (3) has three types of pages - UP, CP and LP
    cell_type = QLC_CELL (4) has four types of pages - UP, CLP, CUP and LP.

    Latency is added to each page access based on this page type.