### PR TITLE
fix complaint about missing prototype on some compilers

### DIFF
--- a/hw/block/femu/nvme.h
+++ b/hw/block/femu/nvme.h
@@ -1441,7 +1441,7 @@ int nvme_register_nossd(FemuCtrl *n);
 int nvme_register_bbssd(FemuCtrl *n);
 int nvme_register_znssd(FemuCtrl *n);
 
-inline uint64_t ns_blks(NvmeNamespace *ns, uint8_t lba_idx)
+static inline uint64_t ns_blks(NvmeNamespace *ns, uint8_t lba_idx)
 {
     FemuCtrl *n = ns->ctrl;
     NvmeIdNs *id_ns = &ns->id_ns;
@@ -1453,7 +1453,7 @@ inline uint64_t ns_blks(NvmeNamespace *ns, uint8_t lba_idx)
     return ns_size / lba_sz;
 }
 
-inline hwaddr nvme_discontig(uint64_t *dma_addr, uint16_t page_size,
+static inline hwaddr nvme_discontig(uint64_t *dma_addr, uint16_t page_size,
     uint16_t queue_idx, uint16_t entry_size)
 {
     uint16_t entries_per_page = page_size / entry_size;
@@ -1463,7 +1463,7 @@ inline hwaddr nvme_discontig(uint64_t *dma_addr, uint16_t page_size,
     return dma_addr[prp_index] + index_in_prp * entry_size;
 }
 
-inline uint16_t nvme_check_mdts(FemuCtrl *n, size_t len)
+static inline uint16_t nvme_check_mdts(FemuCtrl *n, size_t len)
 {
     uint8_t mdts = n->mdts;
 


### PR DESCRIPTION
Some compilers (in my case `gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)`) may complain about missing prototype during the build process:

```
../hw/block/femu/timing-model/../nvme.h:1444:17: error: no previous prototype for ‘ns_blks’ [-Werror=missing-prototypes]
 inline uint64_t ns_blks(NvmeNamespace *ns, uint8_t lba_idx)
                 ^
../hw/block/femu/timing-model/../nvme.h:1456:15: error: no previous prototype for ‘nvme_discontig’ [-Werror=missing-prototypes]
 inline hwaddr nvme_discontig(uint64_t *dma_addr, uint16_t page_size,
               ^
../hw/block/femu/timing-model/../nvme.h:1466:17: error: no previous prototype for ‘nvme_check_mdts’ [-Werror=missing-prototypes]
 inline uint16_t nvme_check_mdts(FemuCtrl *n, size_t len)
                 ^
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
make: *** [run-ninja] Error 1
```

Adding static modifier to relevant functions resolves the issue.