### PR TITLE
fix qmp-vcpu-pin.sh

### DIFF
--- a/femu-scripts/ftk/qmp-vcpu-pin
+++ b/femu-scripts/ftk/qmp-vcpu-pin
@@ -33,13 +33,13 @@ for vcpu in srv.command('query-cpus-fast'):
     vcpuid = vcpu['cpu-index']
     tid = vcpu['thread-id']
     if tid in pinned:
-        print("vCPU{}\'s tid {} already pinned, skipping".format(vcpuid, tid))
+        print 'vCPU{}\'s tid {} already pinned, skipping'.format(vcpuid, tid)
         continue
 
     cpuid = args.cpu[vcpuid % len(args.cpu)]
-    print("Pin vCPU {} (tid {}) to physical CPU {}".format(vcpuid, tid, cpuid))
+    print 'Pin vCPU {} (tid {}) to physical CPU {}'.format(vcpuid, tid, cpuid)
     try:
         call(['taskset', '-pc', str(cpuid), str(tid)], stdout=devnull)
         pinned.append(tid)
     except OSError:
-        print("Failed to pin vCPU{} to CPU{}".format(vcpuid, cpuid))
+        print 'Failed to pin vCPU{} to CPU{}'.format(vcpuid, cpuid)

--- a/femu-scripts/ftk/qmp-vcpu-pin
+++ b/femu-scripts/ftk/qmp-vcpu-pin
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # QEMU vCPU pinning tool
 #
 # Copyright (C) 2016 Red Hat Inc.
@@ -29,17 +29,17 @@ devnull = open(os.devnull, 'w')
 srv = QEMUMonitorProtocol(args.server)
 srv.connect()
 
-for vcpu in srv.command('query-cpus'):
-    vcpuid = vcpu['CPU']
-    tid = vcpu['thread_id']
+for vcpu in srv.command('query-cpus-fast'):
+    vcpuid = vcpu['cpu-index']
+    tid = vcpu['thread-id']
     if tid in pinned:
-        print 'vCPU{}\'s tid {} already pinned, skipping'.format(vcpuid, tid)
+        print("vCPU{}\'s tid {} already pinned, skipping".format(vcpuid, tid))
         continue
 
     cpuid = args.cpu[vcpuid % len(args.cpu)]
-    print 'Pin vCPU {} (tid {}) to physical CPU {}'.format(vcpuid, tid, cpuid)
+    print("Pin vCPU {} (tid {}) to physical CPU {}".format(vcpuid, tid, cpuid))
     try:
         call(['taskset', '-pc', str(cpuid), str(tid)], stdout=devnull)
         pinned.append(tid)
     except OSError:
-        print 'Failed to pin vCPU{} to CPU{}'.format(vcpuid, cpuid)
+        print("Failed to pin vCPU{} to CPU{}".format(vcpuid, cpuid))

--- a/femu-scripts/ftk/qmp.py
+++ b/femu-scripts/ftk/qmp.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python2
 # QEMU Monitor Protocol Python class
 #
 # Copyright (C) 2009, 2010 Red Hat Inc.


### PR DESCRIPTION
`qmp-vcpu-pin.sh` reports error on current version of FEMU due to different monitor commands(I think that's maybe the reason). So I fix it by using new commands.

More than that, I replace `#!/usr/bin/python` with `#!/usr/bin/python2`. Because the version of python is 3 at default in many systems.